### PR TITLE
Upgrade cosmovisor to 1.6.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:1.22.5-bookworm AS base-build
 
-RUN go install cosmossdk.io/tools/cosmovisor/cmd/cosmovisor@v1.5.0
+RUN go install cosmossdk.io/tools/cosmovisor/cmd/cosmovisor@v1.6.0
 RUN go install github.com/hashicorp/go-getter/cmd/go-getter@v1.7.6
 RUN go install github.com/zeta-chain/dl-pipe/cmd/dl-pipe@latest
 


### PR DESCRIPTION
Closes https://github.com/zeta-chain/infrastructure/issues/1596

Blocked by https://github.com/zeta-chain/zetacored-docker/issues/5