### PR TITLE
Support archive multipart snapshots using dl-pipe

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM golang:1.22.5-bookworm AS base-build
 
 RUN go install cosmossdk.io/tools/cosmovisor/cmd/cosmovisor@v1.6.0
 RUN go install github.com/hashicorp/go-getter/cmd/go-getter@v1.7.6
-RUN go install github.com/zeta-chain/dl-pipe/cmd/dl-pipe@latest
+RUN go install github.com/zeta-chain/dl-pipe/cmd/dl-pipe@dd55028ca122ad2577185ae0a5f5e95cd427ccdd
 
 FROM debian:bookworm AS base
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 zetacored-docker is a simple way to run snapshot based `zetacored` in docker. It will automatically download the correct `zetacored` version based on the latest snapshot height. It will also automatically upgrade to the latest version of `zetacored` at upgrade height to ensure minimal downtime.
 
 The only environment variable you must set is `MONIKER`. See `run.sh` for the other variables you may set.
+
+A persistent volume should be mounted on `/root`.

--- a/init.sh
+++ b/init.sh
@@ -117,7 +117,6 @@ restore_snapshot() {
   fi
 }
 
-
 cd $HOME
 
 if [[ -f /root/init_started && ! -f /root/init_completed ]]; then

--- a/init.sh
+++ b/init.sh
@@ -96,16 +96,27 @@ install_genesis_zetacored() {
 
 restore_snapshot() {
   snapshot=$($CURL "${ZETACHAIN_SNAPSHOT_METADATA_URL}" | jq -r '.snapshots[0]')
-  snapshot_link=$(echo "$snapshot" | jq -r '.link')
-  snapshot_md5=$(echo "$snapshot" | jq -r '.checksums.md5')
-  echo "Restoring snapshot from ${snapshot_link}"
-  # https://github.com/zeta-chain/dl-pipe
-  decompress_args=""
-  if [[ "$snapshot_link" == *"lz4"* ]]; then
-    decompress_args="-I lz4"
+  snapshot_type=$(echo "$snapshot" | jq -r '.filename' | grep -q "archive" && echo "archive" || echo "fullnode")
+
+  if [[ "$snapshot_type" == "archive" ]]; then
+    # handle multipart archive snapshots
+    links=$(echo "$snapshot" | jq -r '.links[]')
+    checksum=$(echo "$snapshot" | jq -r '.fullFileChecksum')
+    dl-pipe -progress -hash "sha256:$checksum" "$links" | tar x
+  else
+    echo "Restoring fullnode snapshot"
+    snapshot_link=$(echo "$snapshot" | jq -r '.link')
+    snapshot_md5=$(echo "$snapshot" | jq -r '.checksums.md5')
+    decompress_args=""
+    if [[ "$snapshot_link" == *"lz4"* ]]; then
+      decompress_args="-I lz4"
+    fi
+
+    echo "Downloading and extracting snapshot from ${snapshot_link}"
+    dl-pipe -hash "md5:${snapshot_md5}" "$snapshot_link" | tar "$decompress_args" -x -C "$HOME/.zetacored"
   fi
-  dl-pipe -hash "md5:${snapshot_md5}" "$snapshot_link" | tar $decompress_args -x -C $HOME/.zetacored
 }
+
 
 cd $HOME
 


### PR DESCRIPTION
We migrated our Archive snapshots to a multipart architecture because of most storage services limitations.

- Support Multipart Archive Snapshots download, extract and integrity check using `dl-pipe`.

Related to https://github.com/zeta-chain/dl-pipe/pull/4